### PR TITLE
Add GitHub commit stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 A responsive and minimalistic portfolio website built with modern web standards, featuring a dark/light mode switch.  
 Hosted via **GitHub Pages** for easy access and sharing.
 
+### Features
+
+- Toggleable dark/light mode.
+- Displays the total commits made on GitHub during the last month.
+
 ---
 
 ## 🛠️ Technologies & Languages

--- a/index.html
+++ b/index.html
@@ -110,6 +110,12 @@
           </a>
         </div>
       </section>
+
+      <!-- Sección de estadísticas -->
+      <section class="estadisticas" data-aos="fade-up">
+        <h2>Actividad reciente</h2>
+        <p id="commit-count">Cargando estadísticas...</p>
+      </section>
     </main>
 
     <!-- Pie de página -->
@@ -217,6 +223,34 @@
         duration: 1000,
         once: false, // 👉 se repite cada vez que el elemento entra en viewport
       });
+    </script>
+    <script>
+      async function fetchCommitCount() {
+        const element = document.getElementById("commit-count");
+        try {
+          const response = await fetch(
+            "https://api.github.com/users/gamboaxx/events/public"
+          );
+          if (!response.ok) throw new Error("Network error");
+          const events = await response.json();
+          const cutoff = new Date();
+          cutoff.setMonth(cutoff.getMonth() - 1);
+          let commits = 0;
+          events.forEach((ev) => {
+            if (ev.type === "PushEvent") {
+              const created = new Date(ev.created_at);
+              if (created >= cutoff) {
+                commits += ev.payload.commits.length;
+              }
+            }
+          });
+          element.textContent = `${commits} commits en el último mes`;
+        } catch (err) {
+          element.textContent = "No se pudo obtener la estadística";
+        }
+      }
+
+      fetchCommitCount();
     </script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -40,7 +40,8 @@ main {
 }
 
 .proyectos,
-.contacto {
+.contacto,
+.estadisticas {
   background: white;
   margin-bottom: 2rem;
   padding: 1.5rem;
@@ -243,7 +244,8 @@ body.oscuro header {
 }
 
 body.oscuro .proyectos,
-body.oscuro .contacto {
+body.oscuro .contacto,
+body.oscuro .estadisticas {
   background-color: #2d2d2d;
   color: #e0e0e0;
 }


### PR DESCRIPTION
## Summary
- add features section to README
- display commit stats section in page
- fetch commit total for the last month via GitHub API
- style stats section for light and dark modes

## Testing
- `true`
